### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "mongoose": "6.13.9",
     "passport": "0.5.2",
     "passport-discord": "0.1.4",
-    "typescript": "4.6.2"
+    "typescript": "4.6.2",
+    "express-rate-limit": "^8.3.2"
   },
   "devDependencies": {
     "@types/express": "4.17.13",

--- a/routes/auth.ts
+++ b/routes/auth.ts
@@ -14,10 +14,18 @@ import success from "./views/success";
 import {GuildBan} from "discord.js";
 import badDate from "./views/badDate";
 import config from "../config";
+import rateLimit from "express-rate-limit";
 
-router.get("/discord", passport.authenticate("discord"));
+const loginLimiter = rateLimit({
+    windowMs: 5 * 60 * 1000,
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+});
 
-router.get("/discord/redirect", async (req, res, next) => {
+router.get("/discord", loginLimiter, passport.authenticate("discord"));
+
+router.get("/discord/redirect", loginLimiter, async (req, res, next) => {
 
     try {
         passport.authenticate("discord", (err, user) => {


### PR DESCRIPTION
Potential fix for [https://github.com/OviiiOne/Appeals/security/code-scanning/1](https://github.com/OviiiOne/Appeals/security/code-scanning/1)

In general, the issue is fixed by introducing a rate-limiting middleware (such as `express-rate-limit`) and applying it to routes that perform authorization and/or expensive operations. The middleware should be configured to cap the number of requests from a single client over a time window, returning an appropriate error when the limit is exceeded.

For this file, the least invasive and most targeted fix is to:  
1) Import a well-known rate limiting library (`express-rate-limit`).  
2) Create a limiter instance configured for login/authorization endpoints (e.g., few attempts per minute).  
3) Apply that limiter specifically to the `/discord` and `/discord/redirect` routes, since those are part of the authorization flow that CodeQL is flagging. This keeps existing behavior for normal traffic while preventing abusive bursts.  

Concretely: in `routes/auth.ts`, add an import for `express-rate-limit` near the top; define a `loginLimiter` constant (e.g., 5 requests per 5 minutes per IP, with standard headers); then update the `router.get("/discord", ...)` and `router.get("/discord/redirect", ...)` lines to include `loginLimiter` as middleware, e.g., `router.get("/discord", loginLimiter, passport.authenticate("discord"));` and `router.get("/discord/redirect", loginLimiter, async (req, res, next) => { ... });`. No other behavior of the handlers needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
